### PR TITLE
mainマージ時に自動でリリースタグを打つワークフローを追加

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -22,22 +22,36 @@ jobs:
           set -euo pipefail
 
           today=$(date +%Y-%m-%d)
-          git fetch --tags
-
-          last_seq=0
-          for tag in $(git tag -l "v${today}-*"); do
-            seq="${tag##*-}"
-            if [[ "$seq" =~ ^[0-9]+$ ]] && (( 10#$seq > last_seq )); then
-              last_seq=$((10#$seq))
-            fi
-          done
-
-          next_seq=$((last_seq + 1))
-          new_tag=$(printf "v%s-%02d" "$today" "$next_seq")
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "$new_tag"
-          git push origin "$new_tag"
 
-          echo "Created tag: $new_tag"
+          max_attempts=5
+          attempt=0
+          while [ "$attempt" -lt "$max_attempts" ]; do
+            git fetch --tags --force
+
+            last_seq=0
+            for tag in $(git tag -l "v${today}-*"); do
+              seq="${tag##*-}"
+              if [[ "$seq" =~ ^[0-9]+$ ]] && (( 10#$seq > last_seq )); then
+                last_seq=$((10#$seq))
+              fi
+            done
+
+            next_seq=$((last_seq + 1))
+            new_tag=$(printf "v%s-%02d" "$today" "$next_seq")
+
+            git tag "$new_tag"
+            if git push origin "$new_tag"; then
+              echo "Created tag: $new_tag"
+              exit 0
+            fi
+
+            git tag -d "$new_tag"
+            attempt=$((attempt + 1))
+            echo "Tag $new_tag already exists or push failed, retrying ($attempt/$max_attempts)..."
+          done
+
+          echo "Failed to create tag after $max_attempts attempts"
+          exit 1

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,43 @@
+name: Auto Release Tag
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create incrementing date tag
+        run: |
+          set -euo pipefail
+
+          today=$(date +%Y-%m-%d)
+          git fetch --tags
+
+          last_seq=0
+          for tag in $(git tag -l "v${today}-*"); do
+            seq="${tag##*-}"
+            if [[ "$seq" =~ ^[0-9]+$ ]] && (( 10#$seq > last_seq )); then
+              last_seq=$((10#$seq))
+            fi
+          done
+
+          next_seq=$((last_seq + 1))
+          new_tag=$(printf "v%s-%02d" "$today" "$next_seq")
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$new_tag"
+          git push origin "$new_tag"
+
+          echo "Created tag: $new_tag"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-tag-main
+
 jobs:
   tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `main` ブランチへのマージをトリガーに、`v{yyyy-mm-dd}-{連番}` 形式のタグを自動作成・pushするGitHub Actionsワークフローを追加
- 同日内での実行は既存タグを検索し連番をインクリメント（例: `v2026-07-04-01`, `v2026-07-04-02`）

## Test plan
- [ ] mainにマージして初回タグ `vYYYY-MM-DD-01` が作成されることを確認
- [ ] 同日に再度マージし `vYYYY-MM-DD-02` が作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)