### PR TITLE
CLAUDE.md追加・.venvのgitignore・pytest最小テスト導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.pytest_cache/
 
 # 仮想環境
 .venv/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *$py.class
 
 # 仮想環境
+.venv/
 venv/
 env/
 ENV/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code when working in this repository.
+
+## ワークフロー
+
+- 新規実装をするときは、必ず `main` ブランチを最新化（`git pull` など）してから、そこからブランチを作成した上で実装を始める。`main` を直接更新しない。
+- 実装が完了したら、コミット・プッシュ・PR作成までを都度確認を挟まず自動的に完遂する。

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+
+# pygameをヘッドレス（ディスプレイなし）で動かすため、
+# pygameのimport前にダミードライバを設定する
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+import pygame
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def pygame_session():
+    """テストセッション全体でpygameを初期化する"""
+    pygame.init()
+    yield
+    pygame.quit()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest==8.4.2

--- a/tests/test_progress_system.py
+++ b/tests/test_progress_system.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from aws_icon import AWSIcon
+from progress_system import ProgressSystem
+
+
+@pytest.fixture
+def progress():
+    return ProgressSystem()
+
+
+def make_icon(service_type, position):
+    return AWSIcon(service_type, position, velocity=[0, 0])
+
+
+class TestDependencyAchievements:
+    def test_near_icons_achieve_dependency(self, progress):
+        ec2 = make_icon("EC2", (100, 100))
+        vpc = make_icon("VPC", (150, 100))  # 50px離れ（150px以内）
+
+        progress.check_achievements([ec2, vpc])
+
+        assert progress.dependency_achievements["EC2-VPC"]["achieved"] is True
+
+    def test_far_icons_do_not_achieve_dependency(self, progress):
+        ec2 = make_icon("EC2", (100, 100))
+        vpc = make_icon("VPC", (500, 500))  # 150pxより遠い
+
+        progress.check_achievements([ec2, vpc])
+
+        assert progress.dependency_achievements["EC2-VPC"]["achieved"] is False
+
+    def test_missing_partner_does_not_achieve(self, progress):
+        ec2 = make_icon("EC2", (100, 100))
+
+        progress.check_achievements([ec2])
+
+        assert progress.dependency_achievements["EC2-VPC"]["achieved"] is False
+
+    def test_achievement_persists_after_icons_separate(self, progress):
+        ec2 = make_icon("EC2", (100, 100))
+        vpc = make_icon("VPC", (150, 100))
+        progress.check_achievements([ec2, vpc])
+
+        vpc.rect.center = (700, 500)  # 離す
+        progress.check_achievements([ec2, vpc])
+
+        assert progress.dependency_achievements["EC2-VPC"]["achieved"] is True
+
+
+class TestComplementaryAchievements:
+    def test_interaction_achieves_complementary_relation(self, progress):
+        lam = make_icon("Lambda", (100, 100))
+        dynamo = make_icon("DynamoDB", (150, 100))
+        lam.last_interaction = dynamo
+
+        progress.check_achievements([lam, dynamo])
+
+        assert progress.complementary_achievements["Lambda-DynamoDB"]["achieved"] is True
+
+    def test_no_interaction_no_achievement(self, progress):
+        lam = make_icon("Lambda", (100, 100))
+        dynamo = make_icon("DynamoDB", (150, 100))
+
+        progress.check_achievements([lam, dynamo])
+
+        assert progress.complementary_achievements["Lambda-DynamoDB"]["achieved"] is False
+
+
+class TestNotifications:
+    def test_achievement_adds_notification(self, progress):
+        ec2 = make_icon("EC2", (100, 100))
+        vpc = make_icon("VPC", (150, 100))
+
+        progress.check_achievements([ec2, vpc])
+
+        assert progress.notifications == ["Dependency Achieved: EC2 exists in VPC"]
+
+    def test_duplicate_notification_is_ignored(self, progress):
+        progress.add_notification("same message")
+        progress.add_notification("same message")
+
+        assert progress.notifications == ["same message"]
+
+    def test_notification_expires_after_duration(self, progress):
+        progress.add_notification("temporary")
+
+        for _ in range(progress.notification_duration + 1):
+            progress.update_notifications()
+
+        assert progress.notifications == []
+        assert "temporary" not in progress.notification_timers
+
+
+class TestAchievementRates:
+    def test_initial_rates_are_zero(self, progress):
+        assert progress.get_dependency_achievement_rate() == (0, 6)
+        assert progress.get_complementary_achievement_rate() == (0, 3)
+        assert progress.get_total_achievement_rate() == (0, 9)
+
+    def test_rates_count_achieved_items(self, progress):
+        progress.dependency_achievements["EC2-VPC"]["achieved"] = True
+        progress.complementary_achievements["EC2-EBS"]["achieved"] = True
+
+        assert progress.get_dependency_achievement_rate() == (1, 6)
+        assert progress.get_complementary_achievement_rate() == (1, 3)
+        assert progress.get_total_achievement_rate() == (2, 9)


### PR DESCRIPTION
## Summary
- `CLAUDE.md` を新規作成し、新規実装時はmainを最新化してからブランチを作成すること、実装完了後はコミット・プッシュ・PR作成まで自動で完遂することをルールとして明記
- `.gitignore` に `.venv/` と `.pytest_cache/` を追加
- pytestによる最小テスト構成を導入
  - `conftest.py` で `SDL_VIDEODRIVER=dummy` を設定し、pygameをヘッドレスで実行可能に
  - `tests/test_progress_system.py` で依存関係・補完関係の達成判定、通知の追加/重複排除/期限切れ、達成率計算をカバー（11テスト）
  - `requirements-dev.txt` を追加（pytest）

## Test plan
- [x] `.venv/bin/python -m pytest -v` で11テスト全てパス
- [ ] `.venv/` が `git status` に出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)