### PR TITLE
リリースタグの日付をJSTで計算するよう変更

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          today=$(date +%Y-%m-%d)
+          today=$(TZ=Asia/Tokyo date +%Y-%m-%d)
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- GitHub ActionsランナーはUTCで動作するため、リリースタグの日付がJST基準とずれていた（例: JST 7/4のマージでも `v2026-07-03-XX` になる）
- `date +%Y-%m-%d` を `TZ=Asia/Tokyo date +%Y-%m-%d` に変更し、JST基準の日付でタグを作成するよう修正

## Test plan
- [ ] mainにマージして、JST日付ベースの `vYYYY-MM-DD-01` タグが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)