### PR TITLE
タグ作成後にGitHub Releaseも自動作成するよう変更

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -21,6 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create incrementing date tag
+        id: create_tag
         run: |
           set -euo pipefail
 
@@ -48,6 +49,7 @@ jobs:
             git tag "$new_tag"
             if git push origin "$new_tag"; then
               echo "Created tag: $new_tag"
+              echo "tag=$new_tag" >> "$GITHUB_OUTPUT"
               exit 0
             fi
 
@@ -58,3 +60,13 @@ jobs:
 
           echo "Failed to create tag after $max_attempts attempts"
           exit 1
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.create_tag.outputs.tag }}
+        run: |
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            --target "${{ github.sha }}"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -67,6 +67,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.create_tag.outputs.tag }}
         run: |
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --generate-notes
+          max_attempts=3
+          attempt=0
+          until gh release create "$TAG" --title "$TAG" --generate-notes; do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "Failed to create release for $TAG after $max_attempts attempts (tag was created successfully)"
+              exit 1
+            fi
+            echo "Release creation failed, retrying ($attempt/$max_attempts)..."
+            sleep 5
+          done

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -62,11 +62,11 @@ jobs:
           exit 1
 
       - name: Create GitHub Release
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.create_tag.outputs.tag }}
         run: |
           gh release create "$TAG" \
             --title "$TAG" \
-            --generate-notes \
-            --target "${{ github.sha }}"
+            --generate-notes


### PR DESCRIPTION
## Summary
- `Auto Release Tag` ワークフローで、`vYYYY-MM-DD-XX` タグを作成した後、そのタグに対応するGitHub Releaseも自動作成するように変更
- `gh release create` に `--generate-notes` を指定し、前回リリースからのコミット内容をもとにリリースノートを自動生成
- タグ作成ステップの結果を `GITHUB_OUTPUT` 経由で次ステップに渡すよう変更（`id: create_tag` を追加）

## Test plan
- [ ] mainにマージして、タグ作成に続けてGitHub Releaseが作成されることを確認
- [ ] リリースノートに直前のリリース以降のコミットが反映されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)