### PR TITLE
リタイア通知のservice_typeガード追加（#35レビュー指摘対応）

### DIFF
--- a/main.py
+++ b/main.py
@@ -192,7 +192,10 @@ class Game:
             if icon.health <= 0:
                 dead_icons.add(icon)
             # EC2リタイア発動時に通知を出す（発動した瞬間のみ）
-            if getattr(icon, 'retiring', False) and not icon.retirement_announced:
+            # instance_idはEC2のみが持つため、service_typeでもガードする
+            if (icon.service_type == "EC2"
+                    and getattr(icon, 'retiring', False)
+                    and not icon.retirement_announced):
                 icon.retirement_announced = True
                 self.progress_system.add_notification(
                     self._ec2_retirement_message(icon)

--- a/main.py
+++ b/main.py
@@ -192,9 +192,10 @@ class Game:
             if icon.health <= 0:
                 dead_icons.add(icon)
             # EC2リタイア発動時に通知を出す（発動した瞬間のみ）
-            # instance_idはEC2のみが持つため、service_typeでもガードする
+            # retiring/retirement_announcedは全アイコンで__init__済み。
+            # instance_idはEC2のみが持つため、service_typeでガードする
             if (icon.service_type == "EC2"
-                    and getattr(icon, 'retiring', False)
+                    and icon.retiring
                     and not icon.retirement_announced):
                 icon.retirement_announced = True
                 self.progress_system.add_notification(


### PR DESCRIPTION
## 概要

[#35](https://github.com/sho-saito/aws-icon-life-game/pull/35) のレビュー（amazon-q-developer）で指摘された潜在的クラッシュリスクを修正します。マージ後に気づいたため後追いで対応します。

## 指摘内容

リタイア発動時の通知では、EC2のみが持つ `icon.instance_id` を参照している（`_ec2_retirement_message` 経由）。通知条件は `retiring` フラグしか見ておらず、将来 非EC2アイコンに `retiring=True` が付くと `AttributeError` でクラッシュする恐れがある。

## 変更内容

- 通知条件に `icon.service_type == "EC2"` を追加してガード

```python
if (icon.service_type == "EC2"
        and getattr(icon, 'retiring', False)
        and not icon.retirement_announced):
    ...
```

現状は `retiring` をEC2にしか立てないため実害はないが、防御的に修正。

## テスト

- 全46件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)